### PR TITLE
Don't raise an uncaught exception here

### DIFF
--- a/lib/dyn-js.js
+++ b/lib/dyn-js.js
@@ -69,8 +69,14 @@
       return res.on('end', function() {
         var response;
         log.silly('dyn', "response : " + data);
-        response = JSON.parse(data);
-        return cc(null, response, res);
+        try { 
+          response = JSON.parse(data); 
+        } 
+        catch(ignore) {}
+        if (response) {
+          return cc(null, response, res);
+        }
+        return cc('Invalid JSON response: ' + data);
       });
     });
     req.on('error', function(e) {


### PR DESCRIPTION
Sometimes this will return invalid data.
Instead of throwing an uncaught exception for an operational error,  we should reject the promise.
It's possible my format for the error reporting is off, so if there are any changes that need to be made here, please let me know and I'll reformat it.
